### PR TITLE
address issue#5 CVE-2013-4184 by using HOME

### DIFF
--- a/UUID.h
+++ b/UUID.h
@@ -51,14 +51,13 @@
 #    define  _DEFAULT_UMASK		0007
 #endif
 
-#define UUID_STATE			".UUID_STATE"
-#define UUID_NODEID			".UUID_NODEID"
+#define UUID_STATE			".perl-data-uuid-state"
+#define UUID_NODEID			".perl-data-uuid-nodeid"
+
 #if defined __mingw32__ || (defined _WIN32 && !defined(__cygwin__)) || defined _MSC_VER
-#define UUID_STATE_NV_STORE		_STDIR"\\"UUID_STATE
-#define UUID_NODEID_NV_STORE		_STDIR"\\"UUID_NODEID
+#define PATH_SEPARATOR "\\"
 #else
-#define UUID_STATE_NV_STORE		_STDIR"/"UUID_STATE
-#define UUID_NODEID_NV_STORE		_STDIR"/"UUID_NODEID
+#define PATH_SEPARATOR "/"
 #endif
 
 #define UUIDS_PER_TICK 1024


### PR DESCRIPTION
Fixes rjbs/Data-UUID#5

Fixes: "CVE-2013-4184: Insecure usage of /tmp/.UUID_STATE and /tmp/.UUID_NODEID"

Use HOME environment variable to define the path for the two "nv" files instead of using /tmp.  HOME should always be set on a POSIX system, if it is not, it will default to the original behaviour (which seems to be "/var/tmp").  As such, my patch should not break things any more than the status quo was broken.  Files such as these in HOME should not constitute a security hole because under sane cases HOME should be writable only by the owner, or trusted groups.

I have not written perl XS before, so forgive me if my use of globals to hold the computed directory values is incorrect.  I suppose it could be moved to new() or even create(), though destroy() also uses these variables.  I assume it's better to calc once and remember in globals than calc them every time they are used.  I attempted to maintain the / vs \ file separator distinction as in the original code.  I have no idea if this code will be happy on Windows (HOME set?) but by defaulting to the old behaviour it should not be any "worse".

I made the file names more indicative of what program is creating them, so people don't get too confused or worried about random new files being created willy-nilly.

I did not attempt to try to understand what these files do or if they are really needed.  I am just trying to fix the CVE issue.

If this works out well, I can tackle the other issue tickets, perhaps.  (If crediting the coder/fixer is allowed, please credit me as my full profile name as it helps with my freelance work.)